### PR TITLE
Fix header visibility on home page

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -11,7 +11,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  /* Removed fixed height to keep header visible */
+  padding-top: 2rem;
 }
 
 .title {


### PR DESCRIPTION
## Summary
- remove full viewport height from the index page so the header/menu is visible

## Testing
- `pnpm lint` *(fails: Cannot find module '/workspace/demo-codex/.nuxt/eslint.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_686bf0b66cfc832d8d194b5896f7c3ce